### PR TITLE
Add info to sizes dropdown

### DIFF
--- a/digitaloceanmodule.php
+++ b/digitaloceanmodule.php
@@ -430,7 +430,7 @@ class Digitaloceanmodule extends Module
         $dp = array();
         foreach ($result->sizes as $key => $value) {
             if ($result->sizes[$key]->available == true) {
-                $dp[$result->sizes[$key]->slug] = $result->sizes[$key]->slug;
+                $dp[$tmp->slug] = $tmp->slug . '  ( $' . $tmp->price_monthly . ', RAM: ' . $tmp->memory . ')';
             }
         }
         return $dp;


### PR DESCRIPTION
This PR includes the monthly cost and amount of RAM in the dropdown for the `sizes` menu.